### PR TITLE
[FEATURE] Basic weekly metrics

### DIFF
--- a/kiwi_connector/requestHandler.js
+++ b/kiwi_connector/requestHandler.js
@@ -3,6 +3,8 @@ import Axios from 'axios';
 import AxiosCookieJarSupport from 'axios-cookiejar-support';
 import ToughCookie from 'tough-cookie';
 
+import ConnectionError from '../models/errors/connectionError.js';
+
 AxiosCookieJarSupport.default(Axios);
 
 export default class RequestHandler {
@@ -45,7 +47,12 @@ export default class RequestHandler {
         sendHeaders.Cookie = await this.cookieJar.getCookieString(url);
         
         //Send request & await response
-        const response = await Axios.post(url, JSON.stringify(sendBody), {headers: sendHeaders});
+		const response = await Axios
+			.post(url, JSON.stringify(sendBody), {headers: sendHeaders})
+			.catch(err => {
+				const errMsg = `Network Error   ${err.errno} : ${err.code}`;
+				throw new ConnectionError(errMsg);
+			});
         
         // Save cookies if applicable
         const responseCookies = response.headers['set-cookie'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,31 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -106,10 +131,20 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
     "follow-redirects": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
       "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "has-flag": {
       "version": "4.0.0",
@@ -145,6 +180,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "string-width": {
       "version": "4.2.0",
@@ -249,6 +289,30 @@
           }
         }
       }
+    },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "boxen": "^5.0.0",
     "chalk": "^4.1.0",
     "lodash": "^4.17.20",
-    "tough-cookie": "^4.0.0"
+    "tough-cookie": "^4.0.0",
+    "yargs": "^16.2.0"
   }
 }

--- a/scripts/getWeeklyMetrics.js
+++ b/scripts/getWeeklyMetrics.js
@@ -1,6 +1,8 @@
+#!/usr/bin/env node
 
 import chalk from 'chalk';
 import boxen from 'boxen';
+import yargs from 'yargs';
 
 import TimeUtils from "../utils/TimeUtils.js";
 import TestExecution from '../models/testExecution.js';
@@ -8,15 +10,44 @@ import Kiwi from "../kiwi_connector/kiwi.js";
 import TestExecutionStatus from '../models/testExecutionStatus.js';
 
 // DEV ONLY ignore SSL Certificate
-// process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-// TODO - Accept date from CLI arg
-const sourceDate = new Date();
+const todayDateString = TimeUtils.dateToLocalString(TimeUtils.today(), false);
+
+let args = 
+	yargs(process.argv.slice(2))
+	.scriptName('getWeeklyMetrics')
+	.usage('Usage: $0 -d [anchorDate] -w [weekStartIndex]')
+	.describe('anchorDate', 'Any date within the week of metrics.  Used to calculate start/end of date range.')
+	.default('anchorDate', todayDateString)
+	.alias('d', 'anchorDate')
+	.option('weekStartIndex', {
+		alias: 'w',
+		demandOption: false,
+		default: 0,
+		choices: [0, 1, 2, 3, 4, 5, 6],
+		describe: 'Index of first day of week.  Sun=0, Mon=1, Tues=2 ...',
+		type: 'number'
+	})
+	.alias('h', 'help')
+	.argv;
+
+const sourceDate = new Date(args.anchorDate);
 const startDate = TimeUtils.startOfWeek(sourceDate);
+// adjust for start of week
+const weekStartOffset = args.weekStartIndex;
+if (weekStartOffset > 3) {
+	weekStartOffset -= 7;
+}
+startDate.setDate(startDate.getDate() + weekStartOffset);
 const endDate = TimeUtils.weekAfter(startDate);
 
 const BOXEN_DATE_SETTINGS = {borderStyle: 'classic', 
 							padding: {top: 0, bottom: 0, left: 15, right: 16}};
+const BOXEN_ZERO_TESTEXEC_SETTINGS = {
+	borderStyle: 'singleDouble',
+	padding: { top: 0, bottom: 0, left: 7, right: 8 }
+};
 const NAME_MAX_WIDTH = 10;
 
 const results = {};
@@ -28,12 +59,18 @@ main();
 
 async function main() {
 	await Kiwi.login();
-	outString = `TestExecution Metrics for Week of ${chalk.green(TimeUtils.dateToLocalString(sourceDate))}`;
+	outString = `TestExecution Metrics for Week of ${chalk.green(TimeUtils.dateToLocalString(sourceDate, false))}`;
 	outString += `\n(${chalk.green(TimeUtils.dateToLocalString(startDate))} to ${chalk.green(TimeUtils.dateToLocalString(endDate))})`
 	console.log(boxen(outString, BOXEN_DATE_SETTINGS));
 	
 
 	const ex = await TestExecution.getByDate(startDate, endDate);
+	// Handle case for 0 executions in specified week
+	if (ex.length == 0) {
+		outString = `No TestExecutions found for week of ${chalk.green(TimeUtils.dateToLocalString(startDate, false))} to ${chalk.green(TimeUtils.dateToLocalString(endDate, false))}`;
+		console.log(boxen(outString, BOXEN_ZERO_TESTEXEC_SETTINGS));
+		return;
+	}
 	
 	ex.forEach(el => {
 		const user = el.getTesterUsername();

--- a/utils/TimeUtils.js
+++ b/utils/TimeUtils.js
@@ -87,4 +87,9 @@ export default class TimeUtils {
 		
 		return weekStart;
 	}
+	
+	static stringIsValidDate(string) {
+		const date = new Date(string);
+		return Boolean(+date);
+	}
 }

--- a/utils/TimeUtils.js
+++ b/utils/TimeUtils.js
@@ -15,7 +15,7 @@ export default class TimeUtils {
 		return `${year}-${month}-${day} ${hour}:${min}:${sec}${timeZone}`;
 	}
 	
-	static dateToLocalString(date) {
+	static dateToLocalString(date, includeTime = true) {
 		this._assertDate(date);
 		
 		const day = this._padNumber(date.getDate());
@@ -24,7 +24,13 @@ export default class TimeUtils {
 		const hour = this._padNumber(date.getHours());
 		const min = this._padNumber(date.getMinutes());
 		const sec = this._padNumber(date.getSeconds());
-		return `${year}-${month}-${day} ${hour}:${min}:${sec}`;
+		if (includeTime) {
+			return `${year}-${month}-${day} ${hour}:${min}:${sec}`;
+		}
+		else {
+			return `${year}-${month}-${day}`;
+		}
+		
 	}
 
 	static _padNumber(num, digits = 2) {


### PR DESCRIPTION
[FEATURE] Add script to get weekly test execution metrics for all users in a given week.

Script returns number of pass/fail/block/error/waive test executions for a calendar week.

Week start date can be specified, but defaults to Sunday.

An anchor date can be used to specify which week.  Anchor date can be any day within the calendar week.
Anchor date defaults to current day.