### PR TITLE
Get TestCase Creation metrics as part of weekly metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "debug": "node ./debug/app.js"
+	"debug": "node ./debug/app.js"
   },
   "author": "Jacob N Prymek",
   "private": true,

--- a/readme.md
+++ b/readme.md
@@ -18,12 +18,14 @@ This library uses Kiwi's JSON-RPC API
 `scripts/getWeeklyMetrics.js` provides a summary of test execution results for all users in a given week.  The default starting day of a week is Sunday.  
 Usage:
 ```
-getWeekly Metrics [anchorDate] -w [weekStartIndex]
+getWeeklyMetrics  < -c | -e > [anchorDate] -w [weekStartIndex]
 	Arguments:
 		anchorDate				Any date within the week for which you want metrics.
 								Defaults to current date (local time).
 	Options:
 		-w, --weekStartIndex	Index of first day of week.  Sun=0, Mon=1, Tues=2...
+		-e, -r, --execution		Display TestExecution Metrics (pass/fail/etc) for the specified week
+		-c, -a, --creation		Display TestCase Creation Metrics for the specified week
 		
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -18,14 +18,14 @@ This library uses Kiwi's JSON-RPC API
 `scripts/getWeeklyMetrics.js` provides a summary of test execution results for all users in a given week.  The default starting day of a week is Sunday.  
 Usage:
 ```
-getWeeklyMetrics  < -c | -e > [anchorDate] -w [weekStartIndex]
+getWeeklyMetrics -a  -e [anchorDate] -w [weekStartIndex]
 	Arguments:
 		anchorDate				Any date within the week for which you want metrics.
 								Defaults to current date (local time).
 	Options:
 		-w, --weekStartIndex	Index of first day of week.  Sun=0, Mon=1, Tues=2...
 		-e, -r, --execution		Display TestExecution Metrics (pass/fail/etc) for the specified week
-		-c, -a, --creation		Display TestCase Creation Metrics for the specified week
+		-a, -c, --creation		Display TestCase Creation Metrics for the specified week
 		
 ```
 

--- a/scripts/getWeeklyMetrics.js
+++ b/scripts/getWeeklyMetrics.js
@@ -6,11 +6,13 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import TimeUtils from '../utils/TimeUtils.js';
+import TestCase from '../models/testCase.js';
 import TestExecution from '../models/testExecution.js';
 import Kiwi from '../kiwi_connector/kiwi.js';
 import TestExecutionStatus from '../models/testExecutionStatus.js';
 import ConnectionError from '../models/errors/connectionError.js';
 
+/* #region CLI Arg Settings */
 let args = 
 	yargs(hideBin(process.argv))
 		.scriptName('getWeeklyMetrics')
@@ -42,6 +44,7 @@ let args =
 			return argv.creation || argv.execution;
 		})
 		.argv;
+/* #endregion */
 
 const sourceDate = (args._[0] && TimeUtils.stringIsValidDate(args._[0])) ? new Date(args._[0]) : new Date();
 const startDate = TimeUtils.startOfWeek(sourceDate);
@@ -53,7 +56,7 @@ if (weekStartOffset > 3) {
 startDate.setDate(startDate.getDate() + weekStartOffset);
 const endDate = TimeUtils.weekAfter(startDate);
 
-// Boxen Settings
+/* #region  Boxen Settings */
 const BOXEN_DATE_SETTINGS = {
 	borderStyle: 'classic', 
 	padding: {top: 0, bottom: 0, left: 15, right: 16}
@@ -63,6 +66,18 @@ const BOXEN_ZERO_TESTEXEC_SETTINGS = {
 	borderStyle: 'singleDouble',
 	padding: { top: 0, bottom: 0, left: 7, right: 8 }
 };
+
+const BOXEN_TESTEXEC_SETTINGS = {
+	padding: {
+		'top': 1, 
+		'bottom': 0, 
+		'left': 3, 
+		'right': 3
+	}, 
+	borderStyle: 'classic'
+};
+
+// eslint-disable-next-line no-unused-vars
 const BOXEN_INVISIBLE_SETTINGS = {
 	borderStyle: {
 		topLeft: ' ',
@@ -75,9 +90,22 @@ const BOXEN_INVISIBLE_SETTINGS = {
 	padding : { top: 0, bottom: 0, left: 3, right: 3 }
 };
 
+const BOXEN_TESTCREATED_SETTINGS = {
+	padding: {
+		'top': 1, 
+		'bottom': 0, 
+		'left': 33, 
+		'right': 32
+	}, 
+	borderStyle: 'classic'
+};
+
 const NAME_MAX_WIDTH = 10; // Used for padding user names
 
-const results = {};
+/* #endregion */
+
+const executionResults = {};
+const creationResults = {};
 let outString = '';
 
 //const dateBorderStyle = {topLeft : '', topRight: '', bottomLeft: '', bottomRight: '', horizontal: '-', vertical: '|'}
@@ -86,14 +114,21 @@ main();
 
 async function main() {
 	
-	let stats = null;
-	let ex = null;
+	let execStatuses = null;
+	let testExecutions = null;
+	let testCasesCreated = null;
 	try {
 		await Kiwi.login();
+		
 		if (args.execution) {
-			stats = await TestExecutionStatus.filter({'name__in' : ['PASSED', 'FAILED', 'BLOCKED', 'WAIVED', 'ERROR']});
-			ex = await TestExecution.getByDate(startDate, endDate);
+			execStatuses = await TestExecutionStatus.filter({'name__in' : ['PASSED', 'FAILED', 'BLOCKED', 'WAIVED', 'ERROR']});
+			testExecutions = await TestExecution.getByDate(startDate, endDate);
 		}
+		
+		if(args.creation) {
+			testCasesCreated = await TestCase.getByDateRange(startDate, endDate);
+		}
+		
 		await Kiwi.logout();
 	}
 	catch (err) {
@@ -109,30 +144,31 @@ async function main() {
 		process.exit(1);
 	}
 	
-	if (args.execution && stats && ex) {
-		await printTestExecutionMetrics(stats, ex);
+	if (args.execution && execStatuses && testExecutions) {
+		await printTestExecutionMetrics(execStatuses, testExecutions);
 	}
 	
-	if (args.creation) {
-		outString = chalk.cyan('TestCase creation metrics are not supported yet.  This feature is coming soon.');
-		console.log(boxen(outString, BOXEN_INVISIBLE_SETTINGS));
+	if (args.creation && testCasesCreated) {
+		// outString = chalk.cyan('TestCase creation metrics are not supported yet.  This feature is coming soon.');
+		// console.log(boxen(outString, BOXEN_INVISIBLE_SETTINGS));
+		await printTestCreationMetrics(testCasesCreated);
 	}
 }
 
-async function printTestExecutionMetrics(stats, ex) {
+async function printTestExecutionMetrics(execStats, testExecs) {
 	
 	outString = `TestExecution Metrics for Week of ${chalk.green(TimeUtils.dateToLocalString(sourceDate, false))}`;
 	outString += `\n(${chalk.green(TimeUtils.dateToLocalString(startDate))} to ${chalk.green(TimeUtils.dateToLocalString(endDate))})`;
 	console.log(boxen(outString, BOXEN_DATE_SETTINGS));
 
 	// Handle case for 0 executions in specified week
-	if (ex.length == 0) {
+	if (testExecs.length == 0) {
 		outString = `No TestExecutions found for week of ${chalk.green(TimeUtils.dateToLocalString(startDate, false))} to ${chalk.green(TimeUtils.dateToLocalString(endDate, false))}`;
 		console.log(boxen(outString, BOXEN_ZERO_TESTEXEC_SETTINGS));
 		return;
 	}
 	
-	ex.forEach(el => {
+	testExecs.forEach(el => {
 		const user = el.getTesterUsername();
 		const status = el.getStatusName();
 		upsertExecutionCount(user, status);
@@ -140,15 +176,13 @@ async function printTestExecutionMetrics(stats, ex) {
 	
 	
 	const statColors = {};
-	stats.forEach(stat => {
+	execStats.forEach(stat => {
 		statColors[stat.getName()] = stat.getColor();
 	});
 	
 	outString = '';
-	for (const [userName, userMetrics] of Object.entries(results)) {
+	for (const [userName, userMetrics] of Object.entries(executionResults)) {
 		outString += `${chalk.bold(userName.padStart(NAME_MAX_WIDTH, ' '))} : `;
-		//console.log(userName);
-		//console.log(userMetrics);
 		// Interate through metrics
 		for (const [statName, statColor] of Object.entries(statColors)) {
 			let statCount = userMetrics[statName] || 0;
@@ -158,23 +192,55 @@ async function printTestExecutionMetrics(stats, ex) {
 		//console.log(outString);
 		outString += '\n';
 	}
-	console.log(boxen(outString, {padding: {'top': 1, 'bottom': 0, 'left': 3, 'right': 3}, borderStyle: 'classic'}));
+	console.log(boxen(outString, BOXEN_TESTEXEC_SETTINGS));
 	
 }
 
-/* eslint-disable no-prototype-builtins */
+async function printTestCreationMetrics(testsCreated) {
+	// Print Title Box
+	outString = `TestCase Creation Metrics for Week of ${chalk.green(TimeUtils.dateToLocalString(sourceDate, false))}`;
+	outString += `\n(${chalk.green(TimeUtils.dateToLocalString(startDate))} to ${chalk.green(TimeUtils.dateToLocalString(endDate))})`;
+	console.log(boxen(outString, BOXEN_DATE_SETTINGS));
+	
+	// Handle case for 0 TCs created in specified week
+	if (testsCreated.length == 0) {
+		outString = `No Test Cases were created during ${chalk.green(TimeUtils.dateToLocalString(startDate, false))} to ${chalk.green(TimeUtils.dateToLocalString(endDate, false))}`;
+		console.log(boxen(outString, BOXEN_ZERO_TESTEXEC_SETTINGS));
+		return;
+	}
+	
+	testsCreated.forEach(el => {
+		const user = el.getAuthorName();
+		upsertCreationCount(user);
+	});
+	outString = '';
+	for (const [userName, userMetrics] of Object.entries(creationResults)) {
+		outString += `${chalk.bold(userName.padStart(NAME_MAX_WIDTH, ' '))} : ${userMetrics}`;
+		outString += '\n';
+	}
+	console.log(boxen(outString, BOXEN_TESTCREATED_SETTINGS));
+}
+
+function upsertCreationCount(user) {
+	if(!(creationResults[user])) {
+		creationResults[user] = 0;
+	}
+	creationResults[user] += 1;
+}
+
 function upsertExecutionCount(user, status) {
+	
 	// create new entry for user if not exists
-	if (!(results.hasOwnProperty(user))) {
-		results[user] = {};
+	if (!(executionResults[user])) {
+		executionResults[user] = {};
 	}
 	
 	// create count for status if not exists
-	if (!(results[user]).hasOwnProperty(status)) {
-		results[user][status] = 0;
+	if (!(executionResults[user][status])) {
+		executionResults[user][status] = 0;
 	}
 	
-	results[user][status] += 1;
+	executionResults[user][status] += 1;
 	
 }
 


### PR DESCRIPTION
Adds an additional option to get test case creation metrics.  Execution metrics are now optional, specified by a CLI flag.